### PR TITLE
pre-push: do not pretend that we're a Typescript project

### DIFF
--- a/pre-push.hook
+++ b/pre-push.hook
@@ -33,7 +33,7 @@ git diff --quiet dist/ ||
 die '`dist/` is dirty'
 
 base="$(git rev-list HEAD -1 -- dist/)"
-if test 0 -lt $(git rev-list --count ${base+$base..}HEAD -- \*.ts)
+if test 0 -lt $(git rev-list --count ${base+$base..}HEAD -- \*.js)
 then
     echo "Verifying that dist/ is up to date" >&2
     npm run prepare &&


### PR DESCRIPTION
This fixes the `pre-push` hook so that it _does_ detect when `npm run prepare` needs to be run.