### PR TITLE
ci: automagically repackage when Dependabot updates a dependency

### DIFF
--- a/.github/workflows/npm-run-package.yml
+++ b/.github/workflows/npm-run-package.yml
@@ -1,0 +1,45 @@
+name: 'npm run prepare'
+# Main use case: repackage when Dependabot updates a dependency
+on:
+  push:
+    branches:
+      - 'dependabot/npm_and_yarn/**'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Process this branch'
+        required: false
+        type: string
+
+jobs:
+  npm-run-prepare-and-push: # make sure build/ci work properly
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.repository.owner.login == 'git-for-windows'
+    environment: git-for-windows-ci-push
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.repository.full_name }}
+          ref: ${{ inputs.branch }}${{ github.event.ref }}
+          token: ${{ secrets.GIT_FOR_WINDOWS_CI_PUSH }}
+      - run: npm ci
+      - run: npm run prepare
+      - run: git diff-files
+      - run: npm run lint
+      - run: npm run test
+      - name: check if commit & push is needed
+        id: check
+        run: |
+          git add -u -- dist/ &&
+          git diff-index --cached --exit-code HEAD -- ||
+          echo "::set-output name=need-to-commit::yes"
+      - name: commit & push
+        if: steps.check.outputs.need-to-commit == 'yes'
+        run: |
+          git config user.name "${{github.actor}}" &&
+          git config user.email "${{github.actor}}@users.noreply.github.com" &&
+          git commit -m 'npm run prepare' -- dist/ &&
+          git update-index --refresh &&
+          git diff-files --exit-code &&
+          git diff-index --cached --exit-code HEAD -- &&
+          git push


### PR DESCRIPTION
Dependabot is really cool and helpful, but sometimes it updates a dependency that requires `npm run package` to be run, and Dependabot does not have any way to know that that should happen.

Let's have an automated workflow do that, then.

This is copied from
https://github.com/git-for-windows/setup-git-for-windows-sdk/blob/190c5563/.github/workflows/npm-run-package.yml